### PR TITLE
Allow managing PR workflow without a Trac ticket

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -28,11 +28,10 @@ In this env it can't do many things as it needs access to Trac instance and
 buildbot instance.
 
 You will need a trac and a buildbot set up.
-Create a `build/test_credentials` with the following details on each line:
+Start with a config file based on the sample config and then edit it to
+match your dev env:
 
-* trac credentials
-* buildbot address:port
-* buildmaster PR account
+    cp config.toml build/config.toml
 
 To launch the server use:
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deps: env
 run:
 	@build/bin/python \
 		scripts/start-chevah-github-hooks.py \
-		build/test_credentials \
+		build/config.toml \
 		--port tcp:10041 \
 		--nodaemon
 

--- a/chevah/github_hooks_server/configuration.py
+++ b/chevah/github_hooks_server/configuration.py
@@ -5,7 +5,7 @@ import toml
 def load_configuration(path):
     parsed = toml.load(path)
     if not parsed['chevah'] and not parsed['chevah']['github_hooks_server']:
-        raise RuntiemError('Config section not found.')
+        raise RuntimeError('Config section not found.')
 
     config = parsed['chevah']['github_hooks_server']
 
@@ -48,4 +48,3 @@ def _expand_allowed_ips(configuration, new_value):
     for block in new_value:
         for ip in get_IP_list(block):
             configuration['_allowed_ips'][ip] = True
-

--- a/chevah/github_hooks_server/handler.py
+++ b/chevah/github_hooks_server/handler.py
@@ -96,8 +96,6 @@ class Handler(object):
 
         title = event.content['pull_request']['title']
         ticket_id = self._getTicketFromTitle(title)
-        if not ticket_id:
-            return
 
         state = event.content['review']['state']
         repo = event.content['repository']['full_name']
@@ -151,6 +149,10 @@ class Handler(object):
             log.msg('Failed to get PR %s for %s' % (issue_id, repo))
 
         # Do the Trac stuff.
+        if not ticket_id:
+            # No associated Trac ticket.
+            return
+
         ticket = self.trac.getTicket(ticket_id)
         comment = u'%s requested the review of this ticket.\n\n%s' % (
             user, body)
@@ -175,6 +177,10 @@ class Handler(object):
             log.msg('Failed to get PR %s for %s' % (issue_id, repo))
 
         # Do the Trac stuff.
+        if not ticket_id:
+            # No associated Trac ticket.
+            return
+
         ticket = self.trac.getTicket(ticket_id)
         comment = u'%s needs-changes to this ticket.\n\n%s' % (
             reviewer_name, body)
@@ -211,6 +217,10 @@ class Handler(object):
             log.msg('Failed to get PR %s for %s' % (issue_id, repo))
 
         # Do the Trac stuff.
+        if not ticket_id:
+            # No associated Trac ticket.
+            return
+
         ticket = self.trac.getTicket(ticket_id)
         remaining_reviewers = self._getRemainingReviewers(
             ticket.attributes['cc'], reviewer_name)
@@ -248,8 +258,6 @@ class Handler(object):
 
         message = event.content['issue']['title']
         ticket_id = self._getTicketFromTitle(message)
-        if not ticket_id:
-            return
 
         body = event.content['comment']['body']
         reviewer_name = self._getTracUser(

--- a/chevah/github_hooks_server/handler.py
+++ b/chevah/github_hooks_server/handler.py
@@ -107,7 +107,7 @@ class Handler(object):
 
         reviewers = self._getReviewers(event.content['pull_request']['body'])
 
-        log.msg(u'[%s][%d] New review from %s as %s\n%s' % (
+        log.msg(u'[%s][%s] New review from %s as %s\n%s' % (
             event.hook, ticket_id, reviewer_name, state, body))
 
         if state == 'approved':
@@ -267,7 +267,7 @@ class Handler(object):
 
         reviewers = self._getReviewers(event.content['issue']['body'])
 
-        log.msg(u'[%s][%d] New comment from %s with reviewers %s\n%s' % (
+        log.msg(u'[%s][%s] New comment from %s with reviewers %s\n%s' % (
             event.hook, ticket_id, reviewer_name, reviewers, body))
 
         if self._needsReview(body):

--- a/chevah/github_hooks_server/server.py
+++ b/chevah/github_hooks_server/server.py
@@ -10,7 +10,6 @@ except ImportError:
 
 from klein import resource, route
 
-from cidr import get_IP_list
 from chevah.github_hooks_server import log
 from chevah.github_hooks_server.handler import Handler
 from chevah.github_hooks_server.configuration import CONFIGURATION
@@ -18,20 +17,6 @@ from chevah.github_hooks_server.buildbot_try import BuildbotTryNotifier
 
 # Shut up the linter.
 resource
-
-
-def expand_allowed_ips():
-    """
-    Expand the cached list of allowed ips.
-    """
-    CONFIGURATION['_allowed_ips'] = {}
-
-    for block in CONFIGURATION['allow_cidr']:
-        for ip in get_IP_list(block):
-            CONFIGURATION['_allowed_ips'][ip] = True
-
-# Do initial expansion.
-expand_allowed_ips()
 
 
 class Event(object):

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,27 @@
+[chevah.github_hooks_server]
+
+# Update it from https://api.github.com/meta
+allowed_cidr: [
+        "127.0.0.1/24",
+        "207.97.227.253/32",
+        "50.57.128.197/32",
+        "108.171.174.178/32",
+        "50.57.231.61/32",
+        "204.232.175.64/27",
+        "192.30.252.0/22",
+        ]
+
+
+# URL to Trac XML-RPC API.
+trac-url: mock
+
+# Details for the GitHub server from which hooks are received.
+github-server: github.com
+github-hook-secret: None
+# GitHub API key used by react on GitHub.
+github-token: set-a-token
+
+
+# Address and credentails for the Buildmaster perspective broker.
+buildbot-master: localhost:1080
+buildbot-credentials: user:password

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,11 @@
+0.9.0 (2017-11-12)
+==================
+
+* Add configuration file.
+* Allow changing the review workflow for PR without a Trac ticket.
+
+
+
 0.8.3 (2017-11-02)
 ==================
 

--- a/scripts/start-chevah-github-hooks.py
+++ b/scripts/start-chevah-github-hooks.py
@@ -9,7 +9,7 @@ twistd arguments are only supported in `--option=X` format.
 It also support some non-web twistd commands.
 
 twistd web does not allow passing any extra arguments so we pass them via
-the CONFIGURATION global.
+the configuration file.
 """
 import sys
 import logging
@@ -18,7 +18,7 @@ import logging
 from twisted.scripts.twistd import run
 from twisted.python import log, failure
 
-from chevah.github_hooks_server.configuration import CONFIGURATION
+from chevah.github_hooks_server.configuration import load_configuration
 
 
 class TwistedLogHandler(logging.Handler):
@@ -47,13 +47,7 @@ if __name__ == '__main__':
             'Launch script with at least path to file holding Trac '
             'credentials.')
 
-    # Read Trac credentials and address.
-    with open(sys.argv[1], 'r') as file:
-        lines = file.readlines()
-        CONFIGURATION['trac-url'] = lines[0].strip()
-        CONFIGURATION['buildbot-master'] = lines[1].strip()
-        CONFIGURATION['buildbot-credentials'] = lines[2].strip()
-        CONFIGURATION['github-token'] = lines[3].strip()
+    load_configuration(sys.argv[1])
 
     base_arguments = []
     web_arguments = []

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ distribution = setup(
     scripts=['scripts/start-chevah-github-hooks.py'],
     install_requires=[
         'klein==17.2',
+        'toml',
         # We keep an older version of python is use.
         'Twisted==15.5.0.chevah1',
         'github3-py==1.0.0.gitc82e90e',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Command, find_packages, setup
 import os
 
-VERSION = '0.8.3'
+VERSION = '0.9.0'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
Scope
=====

This in preparation for the migration to GitHub.

This add support for our hook to handle PR even if they don't have an associated Trac ticket

Changes
=======

Make ticket options.

How to test
==========

reviewers: @bgola @hcs0 

check that changes make sense and that you can use the needs-review / needs-changes ... etc for this PR which ha no Trac ticket associated.