### PR TITLE
[Fix #18] Handle GitHub review requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ To create a working virtual environment::
 
     virtualenv -p 3.8 venv  # Last Python version supported by serverless-azure-functions
     . venv/bin/activate
+    pip install poetry
     poetry install
     nodeenv venv/node -n 17.1.0
     . venv/node/bin/activate

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ To run offline for testing purposes, once you have a virtual environment::
     serverless offline
 
 
+Now you can send a POST request to the `hook` function, or a GET request to the `ping` function:
+
+    http://localhost:7071/api/ping
+
 To expose the offline server running on port 7071 to the Web,
 you can use PageKite::
 
@@ -64,6 +68,8 @@ while easily iterating.
 
 Deployment
 ==========
+
+Make sure `config.ini` has an appropriate `github-token` value.
 
 To deploy to Azure Functions::
 
@@ -87,6 +93,13 @@ Troubleshooting
 
 If you get an `Error: EISDIR: illegal operation on a directory, read` during
 deployment, it worked to run `npm install` and try deployment again.
+
+If you get an `Error: Entry not found in cache.` right after
+`Serverless: Creating resource group: sls-weur-dev-githubhooks-rg`,
+remove `~/.azure/slsTokenCache.json` to forget the login tokens and try again
+(which will prompt a re-login).
+See `here <https://github.com/serverless/serverless-azure-functions/issues/412>`_
+for details.
 
 If you keep seeing `Function App not ready. Retry XX of 30...`,
 check out the "Diagnose and solve problems" feature of

--- a/chevah/github_hooks_server/handler.py
+++ b/chevah/github_hooks_server/handler.py
@@ -4,8 +4,6 @@ Custom logic for handling GitHub hooks.
 import re
 import logging
 
-import github3
-
 
 class Handler(object):
     """
@@ -29,8 +27,8 @@ class Handler(object):
     # Helper for tests.
     _current_ticket = None
 
-    def __init__(self, trac_url, github_token):
-        self._github = github3.login(token=github_token)
+    def __init__(self, trac_url, github):
+        self._github = github
         if not self._github:
             raise RuntimeError('Failed to init GitHut.')
 

--- a/chevah/github_hooks_server/handler.py
+++ b/chevah/github_hooks_server/handler.py
@@ -32,7 +32,7 @@ class Handler(object):
         handler = getattr(self, event.name, None)
         if handler is None:
             message = f'No handler for "{event.name}"'
-            logging.warning(message)
+            logging.debug(message)
             return message
 
         return handler(event)
@@ -58,16 +58,9 @@ class Handler(object):
             logging.debug(f"No handler for pull_request action '{action}'.")
             return
 
-        title = event.content['pull_request']['title']
-        ticket_id = self._getTicketFromTitle(title)
-
         repo = event.content['repository']['full_name']
         pull_id = event.content['pull_request']['number']
         reviewers = self._getReviewers(event.content['pull_request']['body'])
-
-        logging.info(
-            f'[{event.name}][{ticket_id}] Review requested from {reviewers}.'
-            )
 
         self._setNeedsReview(
             repo=repo, pull_id=pull_id, reviewers=reviewers, event=event
@@ -85,31 +78,29 @@ class Handler(object):
             logging.info('[%s] Not review submission.' % (event.name))
             return
 
-        title = event.content['pull_request']['title']
-        ticket_id = self._getTicketFromTitle(title)
-
         state = event.content['review']['state']
         repo = event.content['repository']['full_name']
-        issue_id = event.content['pull_request']['number']
+        pull_id = event.content['pull_request']['number']
         author_name = event.content['pull_request']['user']['login']
-        body = event.content['review']['body']
         reviewer_name = event.content['review']['user']['login']
-
-        reviewers = self._getReviewers(event.content['pull_request']['body'])
-
-        logging.info(u'[%s][%s] New review from %s as %s\n%s' % (
-            event.name, ticket_id, reviewer_name, state, body))
 
         if state == 'approved':
             # An approved review comment.
             self._setApproveChanges(
-                repo, ticket_id, issue_id, author_name, reviewer_name, body,
-                reviewers,
+                repo=repo,
+                pull_id=pull_id,
+                author_name=author_name,
+                reviewer_name=reviewer_name,
+                event=event,
                 )
         elif state == 'changes_requested':
             # An needs changes review comment.
             self._setNeedsChanges(
-                repo, ticket_id, issue_id, author_name, reviewer_name, body)
+                repo=repo,
+                pull_id=pull_id,
+                author_name=author_name,
+                event=event,
+                )
         else:
             # Just a simple comment.
             # Do nothing
@@ -129,7 +120,7 @@ class Handler(object):
 
     def _setNeedsReview(self, repo, pull_id, reviewers, event):
         """
-        Set the ticket to needs review.
+        Set the PR to needs review.
         """
         logging.debug(
             f'_setNeedsReview '
@@ -139,7 +130,6 @@ class Handler(object):
             f'reviewers={reviewers}'
             )
 
-        # Do the GitHub stuff
         username, repository = repo.split('/', 1)
         issue = self._github.issue(username, repository, pull_id)
         if issue:
@@ -149,31 +139,43 @@ class Handler(object):
         else:
             logging.error('Failed to get PR %s for %s' % (pull_id, repo))
 
-    def _setNeedsChanges(
-            self, repo, ticket_id, issue_id, author_name, reviewer_name, body):
+    def _setNeedsChanges(self, repo, pull_id, author_name, event):
         """
-        Set the ticket with `ticket_id` in needs changes state.
+        Set the PR with `pull_id` in needs changes state.
         """
-        # Do the GitHub stuff
+        logging.debug(
+            f'_setNeedsChanges '
+            f'event={event.name}, '
+            f'repo={repo}, '
+            f'pull_id={pull_id}, '
+            f'author_name={author_name}'
+            )
+
         username, repository = repo.split('/', 1)
-        issue = self._github.issue(username, repository, issue_id)
+        issue = self._github.issue(username, repository, pull_id)
         if issue:
             issue.add_labels('needs-changes')
             self._removeLabels(issue, ['needs-review', 'needs-merge'])
             issue.edit(assignees=[author_name])
         else:
-            logging.error('Failed to get PR %s for %s' % (issue_id, repo))
+            logging.error('Failed to get PR %s for %s' % (pull_id, repo))
 
     def _setApproveChanges(
-            self, repo, ticket_id, issue_id, author_name, reviewer_name, body,
-            reviewers,
-            ):
+            self, repo, pull_id, author_name, reviewer_name, event):
         """
-        Update the ticket with `ticket_id` as approved.
+        Update the PR with `pull_id` as approved.
         """
-        # Do the GitHub stuff
+        logging.debug(
+            f'_setApproveChanges '
+            f'event={event.name}, '
+            f'repo={repo}, '
+            f'pull_id={pull_id}, '
+            f'author_name={author_name}, '
+            f'reviewer_name={reviewer_name}'
+            )
+
         username, repository = repo.split('/', 1)
-        issue = self._github.issue(username, repository, issue_id)
+        issue = self._github.issue(username, repository, pull_id)
 
         if issue:
             current_reviewers = {u.login for u in issue.assignees}
@@ -188,12 +190,12 @@ class Handler(object):
                 issue.edit(assignees=list(remaining_reviewers))
 
         else:
-            logging.error('Failed to get PR %s for %s' % (issue_id, repo))
+            logging.error('Failed to get PR %s for %s' % (pull_id, repo))
 
     def issue_comment(self, event):
         """
-        At comments on issues which are pull request, check for
-        command and sync state with trac.
+        Look for a command in comments on pull requests,
+        and perform the command.
         """
         if event.content.get('action', 'created') != 'created':
             logging.error('[%s] Not a created issue comment.' % (event.name))
@@ -209,18 +211,12 @@ class Handler(object):
         repo = event.content['repository']['full_name']
         pull_id = event.content['issue']['number']
 
-        message = event.content['issue']['title']
-        ticket_id = self._getTicketFromTitle(message)
-
         body = event.content['comment']['body']
         reviewer_name = event.content['comment']['user']['login']
 
         author_name = event.content['issue']['user']['login']
 
         reviewers = self._getReviewers(event.content['issue']['body'])
-
-        logging.info(u'[%s][%s] New comment from %s with reviewers %s\n%s' % (
-            event.name, ticket_id, reviewer_name, reviewers, body))
 
         if self._needsReview(body):
             self._setNeedsReview(
@@ -229,26 +225,20 @@ class Handler(object):
 
         elif self._needsChanges(body):
             self._setNeedsChanges(
-                repo, ticket_id, pull_id, author_name, reviewer_name, body)
+                repo=repo,
+                pull_id=pull_id,
+                author_name=author_name,
+                event=event,
+                )
 
         elif self._changesApproved(body):
             self._setApproveChanges(
-                repo, ticket_id, pull_id, author_name, reviewer_name, body,
-                reviewers,
+                repo=repo,
+                pull_id=pull_id,
+                author_name=author_name,
+                reviewer_name=reviewer_name,
+                event=event,
                 )
-
-    def _getTicketFromTitle(self, text):
-        """
-        Parse title and return ticket id or None if text
-        does not contains a ticket id.
-        """
-        # https://github.com/chevah/seesaw/pull/12-some.new
-        result = re.match(self.RE_TRAC_TICKET_ID, text)
-        if not result:
-            logging.error(
-                'Pull request has no ticket id in title: %s' % (text,))
-            return
-        return int(result.group(1))
 
     def _getReviewers(self, message):
         """

--- a/chevah/github_hooks_server/handler.py
+++ b/chevah/github_hooks_server/handler.py
@@ -1,8 +1,10 @@
 """
 Custom logic for handling GitHub hooks.
 """
-import re
 import logging
+import re
+
+import github3
 
 
 class Handler(object):
@@ -23,9 +25,6 @@ class Handler(object):
     RE_NEEDS_REVIEW = r'.*needs{0,1}[\-_]review.*'
     RE_NEEDS_CHANGES = r'.*needs{0,1}[\-_]changes{0,1}.*'
     RE_APPROVED = r'.*(changes{0,1}[\-_]approved{0,1})|(approved-at).*'
-
-    # Helper for tests.
-    _current_ticket = None
 
     def __init__(self, trac_url, github):
         self._github = github
@@ -110,6 +109,10 @@ class Handler(object):
         """
         Set the ticket to needs review.
         """
+        logging.debug(
+            f'_setNeedsReview '
+            f'repo={repo}, issue_id={issue_id}, reviewers={reviewers}')
+
         # Do the GitHub stuff
         username, repository = repo.split('/', 1)
         issue = self._github.issue(username, repository, issue_id)

--- a/chevah/github_hooks_server/server.py
+++ b/chevah/github_hooks_server/server.py
@@ -13,6 +13,7 @@ import logging
 from urllib.parse import parse_qs
 
 import azure.functions as func
+import github3
 
 from chevah.github_hooks_server.configuration import CONFIGURATION
 from chevah.github_hooks_server.handler import Handler
@@ -118,7 +119,7 @@ def parse_request(req: func.HttpRequest):
 credentials_and_address = CONFIGURATION.get('trac-url', 'mock')
 handler = Handler(
     trac_url='https://%s/login/xmlrpc' % (credentials_and_address, ),
-    github_token=CONFIGURATION['github-token'],
+    github=github3.login(token=CONFIGURATION['github-token']),
     )
 
 

--- a/chevah/github_hooks_server/server.py
+++ b/chevah/github_hooks_server/server.py
@@ -4,6 +4,7 @@ This is the part where requests are dispatched.
 
 import json
 import logging
+import sys
 from urllib.parse import parse_qs
 
 import azure.functions as func
@@ -11,6 +12,19 @@ import github3
 
 from chevah.github_hooks_server.configuration import CONFIGURATION
 from chevah.github_hooks_server.handler import Handler
+
+
+def handle_exception(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logging.critical(
+        "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+
+
+sys.excepthook = handle_exception
 
 
 class Event(object):

--- a/chevah/github_hooks_server/server.py
+++ b/chevah/github_hooks_server/server.py
@@ -111,10 +111,7 @@ def parse_request(req: func.HttpRequest):
 
 # Set up our hook handler.
 credentials_and_address = CONFIGURATION.get('trac-url', 'mock')
-handler = Handler(
-    trac_url='https://%s/login/xmlrpc' % (credentials_and_address, ),
-    github=github3.login(token=CONFIGURATION['github-token']),
-    )
+handler = Handler(github3.login(token=CONFIGURATION['github-token']))
 
 
 def handle_event(event):

--- a/chevah/github_hooks_server/server.py
+++ b/chevah/github_hooks_server/server.py
@@ -2,13 +2,7 @@
 This is the part where requests are dispatched.
 """
 
-try:
-    import json
-    # Shut up the linter.
-    json
-except ImportError:
-    import simplejson as json
-
+import json
 import logging
 from urllib.parse import parse_qs
 


### PR DESCRIPTION
This is a PR on top of #25; you should probably review that one first.

I removed almost all Trac behavior, and added the `pull_request` handler for review requests, which triggers the `_setNeedsReview` method.

Tell me when/if I should deploy it, so you can easily test it.

reviewers: @adiroiban
